### PR TITLE
Feature/generic impersonated resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ end
 
 As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
 
-```
+```ex
+
 # [...]
 
   defp access_by_role( group_string ) do
@@ -92,11 +93,12 @@ As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
 
 # [...]
 
-  defp sparql_query_for_access_role( group_string ) do
-    "
+  defp sparql_query_for_access_role(group_string) do
+    """
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
 
       SELECT DISTINCT ?session_group ?session_role WHERE {
 
@@ -104,12 +106,16 @@ As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
            \"#{group_string}\"
         }
 
+        VALUES ?session_id {
+           <SESSION_ID>
+        }
+
        {
-          <SESSION_ID> ext:sessionGroup/mu:uuid ?own_group;
+          ?session_id ext:sessionGroup/mu:uuid ?own_group;
                         ext:sessionRole ?session_role.
        } UNION {
 
-         <SESSION_ID> muAccount:impersonates ?maybe_impersonated.
+         ?session_id muAccount:impersonates ?maybe_impersonated.
 
          ?maybe_impersonated a foaf:OnlineAccount;
            ext:sessionRole ?session_role;
@@ -117,11 +123,12 @@ As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
 
          ?person a foaf:Person;
            foaf:account ?maybe_impersonated;
-           foaf:member ?maybe_impersonated_group.
+           foaf:member/mu:uuid ?maybe_impersonated_group.
        }
        BIND(COALESCE(?maybe_impersonated_group, ?own_group) AS ?session_group)
-    }
-    LIMIT 1"
+      }
+      LIMIT 1
+    """
   end
 
 # [...]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Impersonation service
-A microservice that allows users to impersonate other roles.
+A microservice that allows users to impersonate other resources.
 
 ## Tutorials
 ### Add the impersonation-service to a stack
@@ -7,7 +7,7 @@ Add the following snippet to your `docker-compose.yml` file to include the imper
 
 ```yml
 impersonation:
-  image: kanselarij/impersonation-service
+  image: lblod/impersonation-service
 ```
 
 Add rules to the `dispatcher.ex` to dispatch requests to the impersonation service.
@@ -30,10 +30,10 @@ defp access_by_role(role_uris) do
   %AccessByQuery{
     vars: [],
     query: "PREFIX org: <http://www.w3.org/ns/org#>
-            PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+            PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
             SELECT ?role_uri WHERE {
               <SESSION_ID> ext:sessionMembership / org:role ?ownRole .
-              OPTIONAL { <SESSION_ID> ext:impersonatedRole ?maybeImpersonatedRole }
+              OPTIONAL { <SESSION_ID> muAccount:impersonates ?maybeImpersonatedRole }
               BIND(COALESCE(?maybeImpersonatedRole, ?ownRole) AS ?role_uri)
               VALUES ?role_uri { #{Enum.join(role_uris, " ")} }
             } LIMIT 1"
@@ -73,6 +73,79 @@ def user_groups do
 end
 ```
 
+As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
+
+```
+# [...]
+
+  defp access_by_role( group_string ) do
+    %AccessByQuery{
+      vars: ["session_group","session_role"],
+      query: sparql_query_for_access_role( group_string ) }
+  end
+
+  defp access_by_role_for_single_graph( group_string ) do
+    %AccessByQuery{
+      vars: [],
+      query: sparql_query_for_access_role( group_string ) }
+  end
+
+# [...]
+
+  defp sparql_query_for_access_role( group_string ) do
+    "
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+      SELECT DISTINCT ?session_group ?session_role WHERE {
+
+        VALUES ?session_role {
+           \"#{group_string}\"
+        }
+
+       {
+          <SESSION_ID> ext:sessionGroup/mu:uuid ?own_group;
+                        ext:sessionRole ?session_role.
+       } UNION {
+
+         <SESSION_ID> muAccount:impersonates ?maybe_impersonated.
+
+         ?maybe_impersonated a foaf:OnlineAccount;
+           ext:sessionRole ?session_role;
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
+
+         ?person a foaf:Person;
+           foaf:account ?maybe_impersonated;
+           foaf:member ?maybe_impersonated_group.
+       }
+       BIND(COALESCE(?maybe_impersonated_group, ?own_group) AS ?session_group)
+    }
+    LIMIT 1"
+  end
+
+# [...]
+
+def user_groups do
+  [
+    %GroupSpec{
+      name: "sessions-admin",
+      useage: [:read, :write, :read_for_write],
+      access: access_by_role_for_single_graph("LoketAdmin"),
+      graphs: [
+        %GraphSpec{
+          graph: "http://mu.semte.ch/graphs/sessions",
+          constraint: %ResourceFormatConstraint{
+            resource_prefix: "http://mu.semte.ch/sessions/"
+          }
+        },
+      ]
+    },
+  ]
+end
+```
+
+
 ## Reference
 ### Data model
 
@@ -80,16 +153,14 @@ Each logged in user has a session stored in the triplestore. This service works 
 
 ```nq
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionMembership> <http://example.com/membership-id> <http://mu.semte.ch/graphs/sessions> .
 ```
 
-The service works by adding a new triple with the `ext:impersonatedRole` predicate to tell the system which role a user is impersonating.
-After impersonating a role, a user's session would look like this:
+The service works by adding a new triple with the `http://mu.semte.ch/vocabularies/account/impersonation/impersonates` predicate to tell the system which resource a user is impersonating.
+After impersonating a resource a user's session would look like this:
 
 ```nq
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionMembership> <http://example.com/membership-id> <http://mu.semte.ch/graphs/sessions> .
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/impersonatedRole> <http://example.com/role-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/account/impersonation/impersonates> <http://example.com/resource-id> <http://mu.semte.ch/graphs/sessions> .
 ```
 
 ### API
@@ -106,9 +177,9 @@ Fetch the impersonated role linked to the user of the current session.
     "type": "impersonations",
     "id": "impersonation-id",
     "relationships": {
-      "impersonated-role": {
-        "links": "/role/role-id",
-        "data": { "type": "roles", "id": "role-id" }
+      "impersonates": {
+        "links": "/resources/resource-id",
+        "data": { "type": "resources", "id": "resource-id" }
       }
     }
   },
@@ -120,7 +191,7 @@ Fetch the impersonated role linked to the user of the current session.
 
 #### POST `/impersonations`
 
-As the current session, impersonate the provided role. 
+As the current session, impersonate the provided role.
 #### Request body
 
 ```json
@@ -128,8 +199,8 @@ As the current session, impersonate the provided role.
   "data": {
     "type": "impersonations",
     "relationships": {
-      "impersonated-role": {
-        "data": { "type": "roles", "id": "role-id"}
+      "impersonates": {
+        "data": { "type": "resource", "id": "resource-id"}
       }
     }
   }
@@ -145,6 +216,7 @@ As the current session, impersonate the provided role.
 
 ##### 403 Forbidden
 - If the user does not have the necessary authorization to write the session-related triples
+  - Note: mu-auth should be configured to return 403. Else default behaviour of mu-auth remains.
 
 
 #### DELETE `/impersonations/current`
@@ -157,3 +229,4 @@ Remove any impersonation data and reset the session to its original state.
 
 ##### 403 Forbidden
 - If the user does not have the necessary authorization to write the session-related triples
+  - Note: mu-auth should be configured to return 403. Else default behaviour of mu-auth remains.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ impersonation:
 Add rules to the `dispatcher.ex` to dispatch requests to the impersonation service.
 
 ```ex
-match "/impersonations/*path*", @json_service do
-  Proxy.forward conn, path, "http://impersonation/impersonations/"
+match "/impersonations/*path", @json_service do
+  forward conn, path, "http://impersonation/impersonations/"
 end
 ```
 

--- a/app.js
+++ b/app.js
@@ -63,7 +63,7 @@ app.post('/impersonations', async function(req, res, next) {
   const muSessionId = req.get('mu-session-id');
 
   try {
-    const { resource } = await getResource(resourceId);
+    const { uri: resource } = await getResource(resourceId);
     if (resource) {
       await setImpersonatedSession(muSessionId, resource);
     } else {

--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ app.get('/impersonations/current', async function(req, res) {
 
   const {
     id: sessionId,
-    resourceId,
+    impersonatedResourceId,
   } = await getImpersonatedSession(muSessionId);
 
   const data = {
@@ -23,11 +23,11 @@ app.get('/impersonations/current', async function(req, res) {
     id: sessionId,
   };
 
-  if (resourceId) {
+  if (impersonatedResourceId) {
     data.relationships ??= {};
     data.relationships['impersonates'] = {
-      links: `/resources/${resourceId}`,
-      data: { type: 'resources', id: resourceId },
+      links: `/resources/${impersonatedResourceId}`,
+      data: { type: 'resources', id: impersonatedResourceId },
     };
   }
 

--- a/app.js
+++ b/app.js
@@ -63,7 +63,7 @@ app.post('/impersonations', async function(req, res, next) {
   const muSessionId = req.get('mu-session-id');
 
   try {
-    const { uri: resource } = await getResource(resourceId);
+    const { resource } = await getResource(resourceId);
     if (resource) {
       await setImpersonatedSession(muSessionId, resource);
     } else {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -4,15 +4,15 @@ export async function getResource(resourceId) {
   const response = await query(`
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX org: <http://www.w3.org/ns/org#>
-  SELECT DISTINCT ?resource
+  SELECT DISTINCT ?uri
   WHERE {
-    ?resource mu:uuid ${sparqlEscapeString(resourceId)} .
+    ?uri mu:uuid ${sparqlEscapeString(resourceId)} .
   }
   LIMIT 1`);
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
     return {
-      resource: binding.resource.value,
+      uri: binding.uri.value,
     };
   }
   return {};

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -12,7 +12,7 @@ export async function getResource(resourceId) {
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
     return {
-      resrouce: binding.resource.value,
+      resource: binding.resource.value,
     };
   }
   return {};

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,18 +1,18 @@
 import { query, sparqlEscapeString } from 'mu';
 
-export async function getRole(roleId) {
+export async function getResource(resourceId) {
   const response = await query(`
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX org: <http://www.w3.org/ns/org#>
-  SELECT ?uri
+  SELECT DISTINCT ?resource
   WHERE {
-    ?uri a org:Role ; mu:uuid ${sparqlEscapeString(roleId)} .
+    ?resource mu:uuid ${sparqlEscapeString(resourceId)} .
   }
   LIMIT 1`);
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
     return {
-      uri: binding.uri.value,
+      resrouce: binding.resource.value,
     };
   }
   return {};

--- a/lib/session.js
+++ b/lib/session.js
@@ -3,44 +3,44 @@ import { query, update, sparqlEscapeUri } from 'mu';
 export async function getImpersonatedSession(sessionUri) {
   const response = await query(`
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
   SELECT
-    ?uri ?id ?role ?roleId
+    DISTINCT ?uri ?id ?impersonatedResource ?impersonatedResourceId
   WHERE {
     BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
     ?uri mu:uuid ?id ;
-         ext:impersonatedRole ?role .
-    ?role mu:uuid ?roleId .
+         muAccount:impersonates ?impersonatedResource .
+    ?impersonatedResource mu:uuid ?impersonatedResourceId .
   }`);
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
     return {
       uri: binding.uri.value,
       id: binding.id.value,
-      role: binding.role.value,
-      roleId: binding.roleId.value,
+      impersonatedResource: binding.impersonatedResource.value,
+      impersonatedResourceId: binding.impersonatedResourceId.value,
     };
   }
   return {};
 }
 
-export async function setImpersonatedSession(sessionUri, role) {
+export async function setImpersonatedSession(sessionUri, resource) {
   return await update(`
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
   DELETE {
-    ${sparqlEscapeUri(sessionUri)} ext:impersonatedRole ?role .
+    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
   }
   INSERT {
-    ${sparqlEscapeUri(sessionUri)} ext:impersonatedRole ${sparqlEscapeUri(role)} .
+    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ${sparqlEscapeUri(resource)} .
   } WHERE {
-    ${sparqlEscapeUri(sessionUri)} ext:impersonatedRole ?role .
+    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
   }`);
 }
 
 export async function deleteImpersonatedSession(sessionUri) {
   return await update(`
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
   DELETE WHERE {
-    ${sparqlEscapeUri(sessionUri)} ext:impersonatedRole ?role .
+    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
   }`);
 }


### PR DESCRIPTION
We assessed the compatibility of the original service with lblod-projects.
We concluded that an account is a bit more complicated as in Kaleidos, as it uses roles and groups (in most cases at least).
We also deduced that maybe all kinds of resources could be impersonated.
That's why we abstracted `org:Role` to `rdfs:Resource` as the target for impersonated sessions.
We think mu-auth should specify which impersonated resource is valid.
We think the client should figure out (or assume) which specific type
of resource is being impersonated.

Is this crazy?

Context: preparative work for DL-5633