### PR TITLE
Transparent impersonations

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,8 @@ app.get('/impersonations/current', async function (req, res, next) {
     id: sessionId,
     impersonatedResourceId,
     originalResourceId,
+    originalSessionGroupId,
+    originalSessionRoles,
   } = await getImpersonatedSession(muSessionId);
 
   if (!impersonatedResourceId) {
@@ -26,6 +28,9 @@ app.get('/impersonations/current', async function (req, res, next) {
   const data = {
     type: 'impersonations',
     id: sessionId,
+    attributes: {
+      'original-session-roles': originalSessionRoles,
+    },
     relationships: {
       impersonates: {
         links: `/resources/${impersonatedResourceId}`,
@@ -33,6 +38,9 @@ app.get('/impersonations/current', async function (req, res, next) {
       },
       'original-resource': {
         data: { type: 'resources', id: originalResourceId }
+      },
+      'original-session-group': {
+        data: { type: 'session-group', id: originalSessionGroupId }
       }
     }
   };

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ import {
 } from './lib/session';
 import { getResource } from './lib/resource';
 
-app.get('/', function(_req, res) {
+app.get('/', function (_req, res) {
   res.send({ message: '👋 Hi, this is the impersonation-service 🕵' });
 });
 
@@ -16,6 +16,7 @@ app.get('/impersonations/current', async function (req, res, next) {
   const {
     id: sessionId,
     impersonatedResourceId,
+    originalResourceId,
   } = await getImpersonatedSession(muSessionId);
 
   if (!impersonatedResourceId) {
@@ -29,6 +30,9 @@ app.get('/impersonations/current', async function (req, res, next) {
       impersonates: {
         links: `/resources/${impersonatedResourceId}`,
         data: { type: 'resources', id: impersonatedResourceId },
+      },
+      'original-resource': {
+        data: { type: 'resources', id: originalResourceId }
       }
     }
   };
@@ -41,7 +45,7 @@ app.get('/impersonations/current', async function (req, res, next) {
   });
 });
 
-app.post('/impersonations', async function(req, res, next) {
+app.post('/impersonations', async function (req, res, next) {
   let resourceId;
   try {
     ({
@@ -88,7 +92,7 @@ app.post('/impersonations', async function(req, res, next) {
     .send();
 });
 
-app.delete('/impersonations/current', async function(req, res) {
+app.delete('/impersonations/current', async function (req, res) {
   const muSessionId = req.get('mu-session-id');
   try {
     await deleteImpersonatedSession(muSessionId);

--- a/lib/session.js
+++ b/lib/session.js
@@ -42,37 +42,62 @@ export async function getImpersonatedSession(sessionUri) {
 }
 
 export async function setImpersonatedSession(sessionUri, resourceUri) {
-  // TODO, this needs more work for the "choose a new impersonation" flow, it only works for the first impersonation
-  // Not sure how to fix this. We could do a "are we impersonating check" and then execute different queries,
-  // or do some sort of query that first checks the originalX predicates before copying
-
   return await update(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
     PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
-    DELETE {
-      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
-        muExt:sessionGroup ?originalSessionGroup ;
-        muExt:sessionRole ?originalSessionRole .
-    } 
     INSERT {
-      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
-        muExt:sessionGroup ?impersonatedSessionGroup ;
-        muExt:sessionRole ?impersonatedSessionRole ;
+      ?sessionUri
         muExt:originalResource ?originalResource ;
         muExt:originalSessionGroup ?originalSessionGroup ;
         muExt:originalSessionRole ?originalSessionRole .
     }
     WHERE {
-      BIND(${sparqlEscapeUri(resourceUri)} as ?impersonatedAccount)
+      VALUES ?sessionUri {
+        ${sparqlEscapeUri(sessionUri)}
+      }
 
-      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+      ?sessionUri muSession:account ?originalResource ;
         muExt:sessionGroup ?originalSessionGroup ;
         muExt:sessionRole ?originalSessionRole .
 
+      FILTER NOT EXISTS {
+        ?sessionUri
+          muExt:originalResource ?originalResource ;
+          muExt:originalSessionGroup ?originalSessionGroup ;
+          muExt:originalSessionRole ?originalSessionRole .
+      }
+    }
+
+    ;
+
+    DELETE {
+      ?sessionUri muSession:account ?currentResource ;
+        muExt:sessionGroup ?currentSessionGroup ;
+        muExt:sessionRole ?currentSessionRole .
+    }
+    INSERT {
+      ?sessionUri muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole .
+    }
+    WHERE {
+      VALUES ?sessionUri {
+        ${sparqlEscapeUri(sessionUri)}
+      }
+
+      VALUES ?impersonatedAccount {
+        ${sparqlEscapeUri(resourceUri)}
+      }
+
+      ?sessionUri muSession:account ?currentResource ;
+        muExt:sessionGroup ?currentSessionGroup ;
+        muExt:sessionRole ?currentSessionRole .
+
       ?impersonatedAccount muExt:sessionRole ?impersonatedSessionRole .
+
       ?impersonatedUser foaf:account ?impersonatedAccount ;
         foaf:member ?impersonatedSessionGroup .
     }`

--- a/lib/session.js
+++ b/lib/session.js
@@ -2,16 +2,24 @@ import { query, update, sparqlEscapeUri } from 'mu';
 
 export async function getImpersonatedSession(sessionUri) {
   const response = await query(`
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  SELECT
-    DISTINCT ?uri ?id ?impersonatedResource ?impersonatedResourceId
-  WHERE {
-    BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
-    ?uri mu:uuid ?id ;
-         muAccount:impersonates ?impersonatedResource .
-    ?impersonatedResource mu:uuid ?impersonatedResourceId .
-  }`);
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    SELECT DISTINCT 
+      ?uri ?id ?impersonatedResource ?impersonatedResourceId ?originalResource ?originalResourceId
+    WHERE {
+      BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
+      ?uri mu:uuid ?id ;
+        muSession:account ?impersonatedResource ;
+        muExt:originalResource ?originalResource .
+
+      ?impersonatedResource mu:uuid ?impersonatedResourceId .
+      ?originalResource mu:uuid ?originalResourceId .
+    }
+  `);
+
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
     return {
@@ -19,28 +27,77 @@ export async function getImpersonatedSession(sessionUri) {
       id: binding.id.value,
       impersonatedResource: binding.impersonatedResource.value,
       impersonatedResourceId: binding.impersonatedResourceId.value,
+      originalResource: binding.originalResource.value,
+      originalResourceId: binding.originalResourceId.value,
     };
   }
   return {};
 }
 
-export async function setImpersonatedSession(sessionUri, resource) {
+export async function setImpersonatedSession(sessionUri, resourceUri) {
+  // TODO, this needs more work for the "choose a new impersonation" flow, it only works for the first impersonation
+  // Not sure how to fix this. We could do a "are we impersonating check" and then execute different queries,
+  // or do some sort of query that first checks the originalX predicates before copying
+
   return await update(`
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  DELETE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }
-  INSERT {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ${sparqlEscapeUri(resource)} .
-  } WHERE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }`);
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    DELETE {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+        muExt:sessionGroup ?originalSessionGroup ;
+        muExt:sessionRole ?originalSessionRole .
+    } 
+    INSERT {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionGroup ?originalSessionGroup ;
+        muExt:originalSessionRole ?originalSessionRole .
+    }
+    WHERE {
+      BIND(${sparqlEscapeUri(resourceUri)} as ?impersonatedAccount)
+
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+        muExt:sessionGroup ?originalSessionGroup ;
+        muExt:sessionRole ?originalSessionRole .
+
+      ?impersonatedAccount muExt:sessionRole ?impersonatedSessionRole .
+      ?impersonatedUser foaf:account ?impersonatedAccount ;
+        foaf:member ?impersonatedSessionGroup .
+    }`
+  );
 }
 
 export async function deleteImpersonatedSession(sessionUri) {
   return await update(`
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  DELETE WHERE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }`);
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    DELETE {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionRole ?originalSessionRole ;
+        muExt:originalSessionGroup ?originalSessionGroup .
+    } 
+    INSERT {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+        muExt:sessionGroup ?originalSessionGroup ;
+        muExt:sessionRole ?originalSessionRole .
+    }
+    WHERE {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionRole ?originalSessionRole ;
+        muExt:originalSessionGroup ?originalSessionGroup .
+    }`
+  );
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -8,20 +8,25 @@ export async function getImpersonatedSession(sessionUri) {
     PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
     SELECT DISTINCT 
-      ?uri ?id ?impersonatedResource ?impersonatedResourceId ?originalResource ?originalResourceId
+      ?uri ?id ?impersonatedResource ?impersonatedResourceId ?originalResource ?originalResourceId ?originalSessionRoles ?originalSessionGroupId
     WHERE {
       BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
       ?uri mu:uuid ?id ;
         muSession:account ?impersonatedResource ;
-        muExt:originalResource ?originalResource .
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionGroup ?originalSessionGroup ;
+        muExt:originalSessionRole ?originalSessionRoles .
 
       ?impersonatedResource mu:uuid ?impersonatedResourceId .
       ?originalResource mu:uuid ?originalResourceId .
+      ?originalSessionGroup mu:uuid ?originalSessionGroupId .
     }
   `);
 
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
+    const originalSessionRoles = response.results.bindings.map(binding => binding.originalSessionRoles.value);
+
     return {
       uri: binding.uri.value,
       id: binding.id.value,
@@ -29,6 +34,8 @@ export async function getImpersonatedSession(sessionUri) {
       impersonatedResourceId: binding.impersonatedResourceId.value,
       originalResource: binding.originalResource.value,
       originalResourceId: binding.originalResourceId.value,
+      originalSessionGroupId: binding.originalSessionGroupId.value,
+      originalSessionRoles,
     };
   }
   return {};


### PR DESCRIPTION
After some experimentation and feedback we came to the conclusion that the previous implementation isn't transparent enough. Each micro service that accesses session data would need to know about the impersonation which isn't ideal. 

Instead of adding a `muAccount:impersonates` predicate, we override the actual relevant data on the sessios, so the impersonation is "transparent" throughout the stack. This requires app specific knowledge though, so it's not generic at the moment. (The PR assumes an LBLOD app that uses the acmidm-login-service or mock-login-service). We could try to make things configurable so other apps can use it as well.

**TODO**:
- [x] Fix the "switch impersonation", at the moment it only works for the first impersonation
- [ ] Update the mu-auth config example so it works for the new setup
- [ ] double check if the new predicates are good

**Nice to have:**
- [ ] configuration options so it can be used by non-lblod projects and we can upstream the changes to the base repo (and move it to rpio or mu-semtech).

**Current issues when testing in the** [loket PR](https://github.com/lblod/app-digitaal-loket/pull/545):
- ~~stopping the impersonation doesn't work (mu-auth config issue)~~
- ~~switching sessions doesn't work (issue here, and mu-auth config issue)~~
- ~~Loket needs the "group" of the original account to display it in the header, and roles so we can check if the user is an admin (although we can technically assume that if an impersonation is active, since only admins can do that). We don't return these yet. If we do, it's an extra non-generic thing, since not all apps have session groups so it makes it harder to upstream the changes.~~