### PR TITLE
[DL-5849] Transparent impersonations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Impersonation service
-A microservice that allows users to impersonate other resources.
+A microservice that allows users to impersonate other accounts.
 
 ## Tutorials
 ### Add the impersonation-service to a stack
@@ -85,14 +85,14 @@ Each logged in user has a session stored in the triplestore. This service works 
 ```
 
 The service works by copying the original session data to new predicates and replacing them with the impersonated versions afterwards. This way the impersonation is transparent throughout the stack.
-After impersonating a resource a user's session would look like this:
+After impersonating an account a user's session would look like this:
 
 ```nq
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/impersonated-account-id> <http://mu.semte.ch/graphs/sessions> .
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionGroup> <http://example.com/impersonated-group-id> <http://mu.semte.ch/graphs/sessions> .
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionRole> "RoleString" <http://mu.semte.ch/graphs/sessions> .
 
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalResource> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalAccount> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalSessionGroup> <http://example.com/group-id> <http://mu.semte.ch/graphs/sessions> .
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalSessionRole> "RoleString" <http://mu.semte.ch/graphs/sessions> .
 ```
@@ -115,13 +115,13 @@ Fetch the impersonated role linked to the user of the current session.
     },
     "relationships": {
       "impersonates": {
-        "data": { "type": "resources", "id": "resource-id" }
+        "data": { "type": "accounts", "id": "account-id" }
       },
-      "original-resource": {
-        "data": { "type": "resources", "id": "resource-id" }
+      "original-account": {
+        "data": { "type": "accounts", "id": "account-id" }
       },
       "original-session-group": {
-        "data": { "type": "session-group", "id": "group-id" }
+        "data": { "type": "session-groups", "id": "group-id" }
       },
     }
   },
@@ -133,7 +133,7 @@ Fetch the impersonated role linked to the user of the current session.
 
 #### POST `/impersonations`
 
-As the current session, impersonate the provided role.
+As the current session, impersonate the provided account.
 #### Request body
 
 ```json
@@ -142,7 +142,7 @@ As the current session, impersonate the provided role.
     "type": "impersonations",
     "relationships": {
       "impersonates": {
-        "data": { "type": "resource", "id": "resource-id"}
+        "data": { "type": "accounts", "id": "account-id"}
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ def user_groups do
         },
       ]
     },
+    %GroupSpec{
+      name: "org",
+      useage: [:read],
+      access: %AccessByQuery{
+        vars: ["session_group"],
+        # Admin users that are impersonating another account still need access to their organization data
+        query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+                PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+                SELECT DISTINCT ?session_group WHERE {
+                  {
+                    <SESSION_ID> ext:sessionGroup/mu:uuid ?session_group.
+                  } UNION {
+                    <SESSION_ID> ext:originalSessionGroup/mu:uuid ?session_group.
+                  }
+                }" 
+        },
+        graphs: [ %GraphSpec{
+          graph: "http://mu.semte.ch/graphs/organizations/",
+          constraint: %ResourceConstraint{
+            resource_types: [
+              "http://xmlns.com/foaf/0.1/Person",
+              "http://xmlns.com/foaf/0.1/OnlineAccount",
+              "http://www.w3.org/ns/adms#Identifier",
+            ]
+          }
+        } ]
+      },
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -25,111 +25,30 @@ For example, you could have a regular way to determine access based on membershi
 you will automatically receive the data you'd expect to see if you were logged in as a user with the impersonated role.
 But for some operations, like writing session data, you would want to use the role that's linked to the impersonating user.
 
-```ex
-defp access_by_role(role_uris) do
-  %AccessByQuery{
-    vars: [],
-    query: "PREFIX org: <http://www.w3.org/ns/org#>
-            PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-            SELECT ?role_uri WHERE {
-              <SESSION_ID> ext:sessionMembership / org:role ?ownRole .
-              OPTIONAL { <SESSION_ID> muAccount:impersonates ?maybeImpersonatedRole }
-              BIND(COALESCE(?maybeImpersonatedRole, ?ownRole) AS ?role_uri)
-              VALUES ?role_uri { #{Enum.join(role_uris, " ")} }
-            } LIMIT 1"
-  }
-end
-
-defp access_by_own_role(role_uris) do
-  %AccessByQuery{
-    vars: [],
-    query: "PREFIX org: <http://www.w3.org/ns/org#>
-            PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-            SELECT ?role_uri WHERE {
-              <SESSION_ID> ext:sessionMembership / org:role ?role_uri .
-              VALUES ?role_uri { #{Enum.join(role_uris, " ")} }
-            } LIMIT 1"
-  }
-end
-
-# [...]
-
-def user_groups do
-  [
-    %GroupSpec{
-      name: "admin",
-      useage: [:read, :write, :read_for_write],
-      access: access_by_own_role(admin_roles()),
-      graphs: [
-        %GraphSpec{
-          graph: "http://mu.semte.ch/graphs/sessions",
-          constraint: %ResourceFormatConstraint{
-            resource_prefix: "http://mu.semte.ch/sessions/"
-          }
-        },
-      ]
-    },
-  ]
-end
-```
-
-As an `mu-auth` config example closer to `LBLOD` space (`app-digitaal-loket`):
+A `mu-auth` config example close to `LBLOD` space (`app-digitaal-loket`):
 
 ```ex
-
 # [...]
-
-  defp access_by_role( group_string ) do
-    %AccessByQuery{
-      vars: ["session_group","session_role"],
-      query: sparql_query_for_access_role( group_string ) }
-  end
-
-  defp access_by_role_for_single_graph( group_string ) do
-    %AccessByQuery{
-      vars: [],
-      query: sparql_query_for_access_role( group_string ) }
-  end
-
-# [...]
-
-  defp sparql_query_for_access_role(group_string) do
-    """
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-      PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-
-      SELECT DISTINCT ?session_group ?session_role WHERE {
-
+defp is_admin() do
+  %AccessByQuery{
+    vars: [],
+    query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      SELECT DISTINCT ?session_role WHERE {
         VALUES ?session_role {
-           \"#{group_string}\"
+          \"LoketLB-admin\"
         }
-
         VALUES ?session_id {
-           <SESSION_ID>
+          <SESSION_ID>
         }
-
-       {
-          ?session_id ext:sessionGroup/mu:uuid ?own_group;
-                        ext:sessionRole ?session_role.
-       } UNION {
-
-         ?session_id muAccount:impersonates ?maybe_impersonated.
-
-         ?maybe_impersonated a foaf:OnlineAccount;
-           ext:sessionRole ?session_role;
-           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>.
-
-         ?person a foaf:Person;
-           foaf:account ?maybe_impersonated;
-           foaf:member/mu:uuid ?maybe_impersonated_group.
-       }
-       BIND(COALESCE(?maybe_impersonated_group, ?own_group) AS ?session_group)
+        {
+          ?session_id ext:sessionRole ?session_role .
+        } UNION {
+          ?session_id ext:originalSessionRole ?session_role .
+        }
       }
-      LIMIT 1
-    """
-  end
+      LIMIT 1"
+    }
+end
 
 # [...]
 
@@ -138,7 +57,7 @@ def user_groups do
     %GroupSpec{
       name: "sessions-admin",
       useage: [:read, :write, :read_for_write],
-      access: access_by_role_for_single_graph("LoketAdmin"),
+      access: is_admin(),
       graphs: [
         %GraphSpec{
           graph: "http://mu.semte.ch/graphs/sessions",
@@ -156,18 +75,26 @@ end
 ## Reference
 ### Data model
 
-Each logged in user has a session stored in the triplestore. This service works on the assumption that sessions are stored as follows:
+Each logged in user has a session stored in the triplestore. This service works on the assumption that the following the app is using the [acmidm-login-service](https://github.com/lblod/acmidm-login-service) and/or [mock-login-service](https://github.com/lblod/mock-login-service). The session data will be stored as follows:
 
 ```nq
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionGroup> <http://example.com/group-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionRole> "RoleString" <http://mu.semte.ch/graphs/sessions> .
+
 ```
 
-The service works by adding a new triple with the `http://mu.semte.ch/vocabularies/account/impersonation/impersonates` predicate to tell the system which resource a user is impersonating.
+The service works by copying the original session data to new predicates and replacing them with the impersonated versions afterwards. This way the impersonation is transparent throughout the stack.
 After impersonating a resource a user's session would look like this:
 
 ```nq
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
-<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/account/impersonation/impersonates> <http://example.com/resource-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/impersonated-account-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionGroup> <http://example.com/impersonated-group-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/sessionRole> "RoleString" <http://mu.semte.ch/graphs/sessions> .
+
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalResource> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalSessionGroup> <http://example.com/group-id> <http://mu.semte.ch/graphs/sessions> .
+<http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/ext/originalSessionRole> "RoleString" <http://mu.semte.ch/graphs/sessions> .
 ```
 
 ### API
@@ -183,11 +110,19 @@ Fetch the impersonated role linked to the user of the current session.
   "data": {
     "type": "impersonations",
     "id": "impersonation-id",
+    "attributes": {
+      'original-session-roles': ['RoleString']
+    },
     "relationships": {
       "impersonates": {
-        "links": "/resources/resource-id",
         "data": { "type": "resources", "id": "resource-id" }
-      }
+      },
+      "original-resource": {
+        "data": { "type": "resources", "id": "resource-id" }
+      },
+      "original-session-group": {
+        "data": { "type": "session-group", "id": "group-id" }
+      },
     }
   },
   "links": {

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Fetch the impersonated role linked to the user of the current session.
     "type": "impersonations",
     "id": "impersonation-id",
     "attributes": {
-      'original-session-roles': ['RoleString']
+      "original-session-roles": ["RoleString"]
     },
     "relationships": {
       "impersonates": {

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ end
 ## Reference
 ### Data model
 
-Each logged in user has a session stored in the triplestore. This service works on the assumption that the following the app is using the [acmidm-login-service](https://github.com/lblod/acmidm-login-service) and/or [mock-login-service](https://github.com/lblod/mock-login-service). The session data will be stored as follows:
+Each logged in user has a session stored in the triplestore. This service works on the assumption that the host app is using the [acmidm-login-service](https://github.com/lblod/acmidm-login-service) and/or [mock-login-service](https://github.com/lblod/mock-login-service) services. The session data will be stored as follows:
 
 ```nq
 <http://mu.semte.ch/sessions/session-id> <http://mu.semte.ch/vocabularies/session/account> <http://example.com/account-id> <http://mu.semte.ch/graphs/sessions> .

--- a/app.js
+++ b/app.js
@@ -15,13 +15,13 @@ app.get('/impersonations/current', async function (req, res, next) {
 
   const {
     id: sessionId,
-    impersonatedResourceId,
-    originalResourceId,
+    impersonatedAccountId,
+    originalAccountId,
     originalSessionGroupId,
     originalSessionRoles,
   } = await getImpersonatedSession(muSessionId);
 
-  if (!impersonatedResourceId) {
+  if (!impersonatedAccountId) {
     return next({ message: 'No active impersonation' });
   }
 
@@ -33,14 +33,13 @@ app.get('/impersonations/current', async function (req, res, next) {
     },
     relationships: {
       impersonates: {
-        links: `/resources/${impersonatedResourceId}`,
-        data: { type: 'resources', id: impersonatedResourceId },
+        data: { type: 'accounts', id: impersonatedAccountId },
       },
-      'original-resource': {
-        data: { type: 'resources', id: originalResourceId }
+      'original-account': {
+        data: { type: 'accounts', id: originalAccountId }
       },
       'original-session-group': {
-        data: { type: 'session-group', id: originalSessionGroupId }
+        data: { type: 'session-groups', id: originalSessionGroupId }
       }
     }
   };
@@ -54,21 +53,21 @@ app.get('/impersonations/current', async function (req, res, next) {
 });
 
 app.post('/impersonations', async function (req, res, next) {
-  let resourceId;
+  let accountId;
   try {
     ({
       data: {
         relationships: {
           'impersonates': {
             data: {
-              id: resourceId
+              id: accountId
             }
           }
         }
       }
     } = req.body);
-    if (!resourceId) {
-      return next({ message: `You need to pass a resource ID in the request body` });
+    if (!accountId) {
+      return next({ message: `You need to pass an account id in the request body` });
     }
   } catch (e) {
     return next({ message: `Failed to parse the request body` });
@@ -77,18 +76,18 @@ app.post('/impersonations', async function (req, res, next) {
   const muSessionId = req.get('mu-session-id');
 
   try {
-    const { uri: resource } = await getResource(resourceId);
-    if (resource) {
-      await setImpersonatedSession(muSessionId, resource);
+    const { uri: accountUri } = await getResource(accountId);
+    if (accountUri) {
+      await setImpersonatedSession(muSessionId, accountUri);
     } else {
-      return next({ message: `Could not find a resource with id ${resourceId}`, status: 404 });
+      return next({ message: `Could not find a account with id ${accountId}`, status: 404 });
     }
   } catch (e) {
     if (e.httpStatus === 403) {
-      console.warn(`Session <${muSessionId}> could not write data to impersonate resource  with id: <${resourceId}>`);
+      console.warn(`Session <${muSessionId}> could not write data to impersonate account  with id: <${accountId}>`);
       return next({ message: `You don't have the necessary rights to impersonate other roles`, status: 403 });
     } else {
-      console.warn(`Something went wrong while session <${muSessionId}> tried to impersonate resource  with id: <${resourceId}>`);
+      console.warn(`Something went wrong while session <${muSessionId}> tried to impersonate account with id: <${accountId}>`);
       console.error(e);
       return next({ message: 'Something went wrong' });
     }

--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@ import {
 } from './lib/session';
 import { getResource } from './lib/resource';
 
-app.get('/', function(_req, res) {
+app.get('/', function (_req, res) {
   res.send({ message: '👋 Hi, this is the impersonation-service 🕵' });
 });
 
@@ -16,6 +16,9 @@ app.get('/impersonations/current', async function (req, res, next) {
   const {
     id: sessionId,
     impersonatedResourceId,
+    originalResourceId,
+    originalSessionGroupId,
+    originalSessionRoles,
   } = await getImpersonatedSession(muSessionId);
 
   if (!impersonatedResourceId) {
@@ -25,10 +28,19 @@ app.get('/impersonations/current', async function (req, res, next) {
   const data = {
     type: 'impersonations',
     id: sessionId,
+    attributes: {
+      'original-session-roles': originalSessionRoles,
+    },
     relationships: {
       impersonates: {
         links: `/resources/${impersonatedResourceId}`,
         data: { type: 'resources', id: impersonatedResourceId },
+      },
+      'original-resource': {
+        data: { type: 'resources', id: originalResourceId }
+      },
+      'original-session-group': {
+        data: { type: 'session-group', id: originalSessionGroupId }
       }
     }
   };
@@ -41,7 +53,7 @@ app.get('/impersonations/current', async function (req, res, next) {
   });
 });
 
-app.post('/impersonations', async function(req, res, next) {
+app.post('/impersonations', async function (req, res, next) {
   let resourceId;
   try {
     ({
@@ -88,7 +100,7 @@ app.post('/impersonations', async function(req, res, next) {
     .send();
 });
 
-app.delete('/impersonations/current', async function(req, res) {
+app.delete('/impersonations/current', async function (req, res) {
   const muSessionId = req.get('mu-session-id');
   try {
     await deleteImpersonatedSession(muSessionId);

--- a/lib/session.js
+++ b/lib/session.js
@@ -8,17 +8,17 @@ export async function getImpersonatedSession(sessionUri) {
     PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
     SELECT DISTINCT 
-      ?uri ?id ?impersonatedResource ?impersonatedResourceId ?originalResource ?originalResourceId ?originalSessionRoles ?originalSessionGroupId
+      ?uri ?id ?impersonatedAccount ?impersonatedAccountId ?originalAccount ?originalAccountId ?originalSessionRoles ?originalSessionGroupId
     WHERE {
       BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
       ?uri mu:uuid ?id ;
-        muSession:account ?impersonatedResource ;
-        muExt:originalResource ?originalResource ;
+        muSession:account ?impersonatedAccount ;
+        muExt:originalAccount ?originalAccount ;
         muExt:originalSessionGroup ?originalSessionGroup ;
         muExt:originalSessionRole ?originalSessionRoles .
 
-      ?impersonatedResource mu:uuid ?impersonatedResourceId .
-      ?originalResource mu:uuid ?originalResourceId .
+      ?impersonatedAccount mu:uuid ?impersonatedAccountId .
+      ?originalAccount mu:uuid ?originalAccountId .
       ?originalSessionGroup mu:uuid ?originalSessionGroupId .
     }
   `);
@@ -30,10 +30,10 @@ export async function getImpersonatedSession(sessionUri) {
     return {
       uri: binding.uri.value,
       id: binding.id.value,
-      impersonatedResource: binding.impersonatedResource.value,
-      impersonatedResourceId: binding.impersonatedResourceId.value,
-      originalResource: binding.originalResource.value,
-      originalResourceId: binding.originalResourceId.value,
+      impersonatedAccount: binding.impersonatedAccount.value,
+      impersonatedAccountId: binding.impersonatedAccountId.value,
+      originalAccount: binding.originalAccount.value,
+      originalAccountId: binding.originalAccountId.value,
       originalSessionGroupId: binding.originalSessionGroupId.value,
       originalSessionRoles,
     };
@@ -41,7 +41,7 @@ export async function getImpersonatedSession(sessionUri) {
   return {};
 }
 
-export async function setImpersonatedSession(sessionUri, resourceUri) {
+export async function setImpersonatedSession(sessionUri, accountUri) {
   return await update(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -50,7 +50,7 @@ export async function setImpersonatedSession(sessionUri, resourceUri) {
 
     INSERT {
       ?sessionUri
-        muExt:originalResource ?originalResource ;
+        muExt:originalAccount ?originalAccount ;
         muExt:originalSessionGroup ?originalSessionGroup ;
         muExt:originalSessionRole ?originalSessionRole .
     }
@@ -59,13 +59,13 @@ export async function setImpersonatedSession(sessionUri, resourceUri) {
         ${sparqlEscapeUri(sessionUri)}
       }
 
-      ?sessionUri muSession:account ?originalResource ;
+      ?sessionUri muSession:account ?originalAccount ;
         muExt:sessionGroup ?originalSessionGroup ;
         muExt:sessionRole ?originalSessionRole .
 
       FILTER NOT EXISTS {
         ?sessionUri
-          muExt:originalResource ?maybeOriginalResource ;
+          muExt:originalAccount ?maybeoriginalAccount ;
           muExt:originalSessionGroup ?maybeOriginalSessionGroup ;
           muExt:originalSessionRole ?maybeOriginalSessionRole .
       }
@@ -74,7 +74,7 @@ export async function setImpersonatedSession(sessionUri, resourceUri) {
     ;
 
     DELETE {
-      ?sessionUri muSession:account ?currentResource ;
+      ?sessionUri muSession:account ?currentAccount ;
         muExt:sessionGroup ?currentSessionGroup ;
         muExt:sessionRole ?currentSessionRole .
     }
@@ -89,10 +89,10 @@ export async function setImpersonatedSession(sessionUri, resourceUri) {
       }
 
       VALUES ?impersonatedAccount {
-        ${sparqlEscapeUri(resourceUri)}
+        ${sparqlEscapeUri(accountUri)}
       }
 
-      ?sessionUri muSession:account ?currentResource ;
+      ?sessionUri muSession:account ?currentAccount ;
         muExt:sessionGroup ?currentSessionGroup ;
         muExt:sessionRole ?currentSessionRole .
 
@@ -114,12 +114,12 @@ export async function deleteImpersonatedSession(sessionUri) {
       ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
         muExt:sessionGroup ?impersonatedSessionGroup ;
         muExt:sessionRole ?impersonatedSessionRole ;
-        muExt:originalResource ?originalResource ;
+        muExt:originalAccount ?originalAccount ;
         muExt:originalSessionRole ?originalSessionRole ;
         muExt:originalSessionGroup ?originalSessionGroup .
     } 
     INSERT {
-      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalAccount ;
         muExt:sessionGroup ?originalSessionGroup ;
         muExt:sessionRole ?originalSessionRole .
     }
@@ -127,7 +127,7 @@ export async function deleteImpersonatedSession(sessionUri) {
       ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
         muExt:sessionGroup ?impersonatedSessionGroup ;
         muExt:sessionRole ?impersonatedSessionRole ;
-        muExt:originalResource ?originalResource ;
+        muExt:originalAccount ?originalAccount ;
         muExt:originalSessionRole ?originalSessionRole ;
         muExt:originalSessionGroup ?originalSessionGroup .
     }`

--- a/lib/session.js
+++ b/lib/session.js
@@ -65,9 +65,9 @@ export async function setImpersonatedSession(sessionUri, resourceUri) {
 
       FILTER NOT EXISTS {
         ?sessionUri
-          muExt:originalResource ?originalResource ;
-          muExt:originalSessionGroup ?originalSessionGroup ;
-          muExt:originalSessionRole ?originalSessionRole .
+          muExt:originalResource ?maybeOriginalResource ;
+          muExt:originalSessionGroup ?maybeOriginalSessionGroup ;
+          muExt:originalSessionRole ?maybeOriginalSessionRole .
       }
     }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -2,45 +2,134 @@ import { query, update, sparqlEscapeUri } from 'mu';
 
 export async function getImpersonatedSession(sessionUri) {
   const response = await query(`
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  SELECT
-    DISTINCT ?uri ?id ?impersonatedResource ?impersonatedResourceId
-  WHERE {
-    BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
-    ?uri mu:uuid ?id ;
-         muAccount:impersonates ?impersonatedResource .
-    ?impersonatedResource mu:uuid ?impersonatedResourceId .
-  }`);
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    SELECT DISTINCT 
+      ?uri ?id ?impersonatedResource ?impersonatedResourceId ?originalResource ?originalResourceId ?originalSessionRoles ?originalSessionGroupId
+    WHERE {
+      BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
+      ?uri mu:uuid ?id ;
+        muSession:account ?impersonatedResource ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionGroup ?originalSessionGroup ;
+        muExt:originalSessionRole ?originalSessionRoles .
+
+      ?impersonatedResource mu:uuid ?impersonatedResourceId .
+      ?originalResource mu:uuid ?originalResourceId .
+      ?originalSessionGroup mu:uuid ?originalSessionGroupId .
+    }
+  `);
+
   if (response.results.bindings.length) {
     const binding = response.results.bindings[0];
+    const originalSessionRoles = response.results.bindings.map(binding => binding.originalSessionRoles.value);
+
     return {
       uri: binding.uri.value,
       id: binding.id.value,
       impersonatedResource: binding.impersonatedResource.value,
       impersonatedResourceId: binding.impersonatedResourceId.value,
+      originalResource: binding.originalResource.value,
+      originalResourceId: binding.originalResourceId.value,
+      originalSessionGroupId: binding.originalSessionGroupId.value,
+      originalSessionRoles,
     };
   }
   return {};
 }
 
-export async function setImpersonatedSession(sessionUri, resource) {
+export async function setImpersonatedSession(sessionUri, resourceUri) {
   return await update(`
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  DELETE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }
-  INSERT {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ${sparqlEscapeUri(resource)} .
-  } WHERE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }`);
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    INSERT {
+      ?sessionUri
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionGroup ?originalSessionGroup ;
+        muExt:originalSessionRole ?originalSessionRole .
+    }
+    WHERE {
+      VALUES ?sessionUri {
+        ${sparqlEscapeUri(sessionUri)}
+      }
+
+      ?sessionUri muSession:account ?originalResource ;
+        muExt:sessionGroup ?originalSessionGroup ;
+        muExt:sessionRole ?originalSessionRole .
+
+      FILTER NOT EXISTS {
+        ?sessionUri
+          muExt:originalResource ?originalResource ;
+          muExt:originalSessionGroup ?originalSessionGroup ;
+          muExt:originalSessionRole ?originalSessionRole .
+      }
+    }
+
+    ;
+
+    DELETE {
+      ?sessionUri muSession:account ?currentResource ;
+        muExt:sessionGroup ?currentSessionGroup ;
+        muExt:sessionRole ?currentSessionRole .
+    }
+    INSERT {
+      ?sessionUri muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole .
+    }
+    WHERE {
+      VALUES ?sessionUri {
+        ${sparqlEscapeUri(sessionUri)}
+      }
+
+      VALUES ?impersonatedAccount {
+        ${sparqlEscapeUri(resourceUri)}
+      }
+
+      ?sessionUri muSession:account ?currentResource ;
+        muExt:sessionGroup ?currentSessionGroup ;
+        muExt:sessionRole ?currentSessionRole .
+
+      ?impersonatedAccount muExt:sessionRole ?impersonatedSessionRole .
+
+      ?impersonatedUser foaf:account ?impersonatedAccount ;
+        foaf:member ?impersonatedSessionGroup .
+    }`
+  );
 }
 
 export async function deleteImpersonatedSession(sessionUri) {
   return await update(`
-  PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
-  DELETE WHERE {
-    ${sparqlEscapeUri(sessionUri)} muAccount:impersonates ?resource .
-  }`);
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    DELETE {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionRole ?originalSessionRole ;
+        muExt:originalSessionGroup ?originalSessionGroup .
+    } 
+    INSERT {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?originalResource ;
+        muExt:sessionGroup ?originalSessionGroup ;
+        muExt:sessionRole ?originalSessionRole .
+    }
+    WHERE {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+        muExt:sessionGroup ?impersonatedSessionGroup ;
+        muExt:sessionRole ?impersonatedSessionRole ;
+        muExt:originalResource ?originalResource ;
+        muExt:originalSessionRole ?originalSessionRole ;
+        muExt:originalSessionGroup ?originalSessionGroup .
+    }`
+  );
 }


### PR DESCRIPTION
After some experimentation and feedback we came to the conclusion that the previous implementation isn't transparent enough. Each micro service that accesses session data would need to know about the impersonation which isn't ideal. 

Instead of adding a `muAccount:impersonates` predicate, we override the actual relevant data on the sessios, so the impersonation is "transparent" throughout the stack. This requires app specific knowledge though, so it's not generic at the moment. (The PR assumes an LBLOD app that uses the acmidm-login-service or mock-login-service). We could try to make things configurable so other apps can use it as well.

**TODO**:
- [x] Fix the "switch impersonation", at the moment it only works for the first impersonation
- [x] Update the mu-auth config example so it works for the new setup
- [ ] double check if the new predicates are good

**Nice to have:**
- [ ] ~~configuration options so it can be used by non-lblod projects and we can upstream the changes to the base repo (and move it to rpio or mu-semtech).~~ Out of scope for now.

**Current issues when testing in the** [loket PR](https://github.com/lblod/app-digitaal-loket/pull/545):
- ~~stopping the impersonation doesn't work (mu-auth config issue)~~
- ~~switching sessions doesn't work (issue here, and mu-auth config issue)~~
- ~~Loket needs the "group" of the original account to display it in the header, and roles so we can check if the user is an admin (although we can technically assume that if an impersonation is active, since only admins can do that). We don't return these yet. If we do, it's an extra non-generic thing, since not all apps have session groups so it makes it harder to upstream the changes.~~