### PR TITLE
Split insert impersonation query into parts

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -7,7 +7,7 @@ export async function getImpersonatedSession(sessionUri) {
     PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/impersonation/>
     PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
-    SELECT DISTINCT 
+    SELECT DISTINCT
       ?uri ?id ?impersonatedAccount ?impersonatedAccountId ?originalAccount ?originalAccountId ?originalSessionRoles ?originalSessionGroupId
     WHERE {
       BIND(${sparqlEscapeUri(sessionUri)} AS ?uri)
@@ -83,12 +83,12 @@ export async function setImpersonatedSession(sessionUri, accountUri) {
     PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
     PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
-    SELECT DISTINCT
-      ?impersonatedAccount
-      ?impersonatedSessionGroup
-      ?impersonatedSessionRole
-
-     WHERE {
+    CONSTRUCT {
+      ${sparqlEscapeUri(sessionUri)} muSession:account ?impersonatedAccount ;
+          muExt:sessionGroup ?impersonatedSessionGroup ;
+          muExt:sessionRole ?impersonatedSessionRole .
+    }
+    WHERE {
 
       VALUES ?impersonatedAccount {
         ${sparqlEscapeUri(accountUri)}
@@ -101,7 +101,8 @@ export async function setImpersonatedSession(sessionUri, accountUri) {
       }
   `;
 
-  const results = parseResult(await query(getDataToImpersonateQuery));
+  const results = (await query(getDataToImpersonateQuery))?.results?.bindings || [];
+  const triples = toTermObjectArray(results)
 
   const removeOldSessionQuery = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -125,21 +126,17 @@ export async function setImpersonatedSession(sessionUri, accountUri) {
 
   await update(removeOldSessionQuery);
 
-  for(const result of results) {
-    const insertNewSessionQuery = `
-      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-      PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+  const insertNewSessionQuery = `
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
-      INSERT DATA {
-        ${sparqlEscapeUri(sessionUri)} muSession:account ${sparqlEscapeUri(result['impersonatedAccount'])} ;
-          muExt:sessionGroup ${sparqlEscapeUri(result['impersonatedSessionGroup'])} ;
-          muExt:sessionRole ${sparqlEscapeString(result['impersonatedSessionRole'])} .
-      }
-    `;
-    await update(insertNewSessionQuery);
-  }
+    INSERT DATA {
+       ${triples.join(".\n")}
+    }`;
+
+  await update(insertNewSessionQuery);
 
 }
 
@@ -174,26 +171,33 @@ export async function deleteImpersonatedSession(sessionUri) {
 }
 
 /**
- * convert results of select query to an array of objects.
- * courtesy: Niels Vandekeybus & Felix
- * @method parseResult
- * @return {Array}
+ * Transform an array of triples to a string of statements to use in a SPARQL query
+ *
+ * @param {Array} triples Array of triples to convert
+ * @method toTermObjectArray
+ * @private
  */
-function parseResult(result) {
-  if (!(result.results && result.results.bindings.length)) return [];
+export function toTermObjectArray(triples) {
+  const escape = function (rdfTerm) {
+    const { type, value, datatype } = rdfTerm;
+    // Might not be ideal: two ways of anotating language
+    //   xml:lang  conforms to https://www.w3.org/TR/sparql11-results-json/
+    //   lang      conforms to https://www.w3.org/TR/rdf-json/
+    // We look for both to capture all intentions.
+    const lang = rdfTerm['xml:lang'] || rdfTerm?.lang;
+    if (type === 'uri') {
+      return sparqlEscapeUri(value);
+    } else if (type === 'literal' || type === 'typed-literal') {
+      if (datatype)
+        return `${sparqlEscapeString(value.toString())}^^${sparqlEscapeUri(datatype)}`;
+      else if (lang)
+        return `${sparqlEscapeString(value)}@${lang}`;
+      else
+        return `${sparqlEscapeString(value)}`;
+    } else
+      console.log(`Don't know how to escape type ${type}. Will escape as a string.`);
+    return sparqlEscapeString(value);
+  };
 
-  const bindingKeys = result.head.vars;
-  return result.results.bindings.map((row) => {
-    const obj = {};
-    bindingKeys.forEach((key) => {
-      if (row[key] && row[key].datatype == 'http://www.w3.org/2001/XMLSchema#integer' && row[key].value) {
-        obj[key] = parseInt(row[key].value);
-      }
-      else if (row[key] && row[key].datatype == 'http://www.w3.org/2001/XMLSchema#dateTime' && row[key].value) {
-        obj[key] = new Date(row[key].value);
-      }
-      else obj[key] = row[key] ? row[key].value : undefined;
-    });
-    return obj;
-  });
-};
+  return triples.map(t => `${escape(t.s)} ${escape(t.p)} ${escape(t.o)}`);
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -43,9 +43,10 @@ export async function getImpersonatedSession(sessionUri) {
 
 export async function setImpersonatedSession(sessionUri, accountUri) {
 
-  // The query has been split in pieces, because mu-auth is a bit restrictive
-  // If you need to write data to a graph you're permitted to write, but with data
-  // from a graph you're only required to read.
+  // The query is split into pieces due to mu-auth restrictions.
+  // You can write data to a graph you have write permissions for,
+  // but mu-auth won't perform DELETE/INSERT operations if the data
+  // originates from a read-only graph.
   const insertOriginalAccountQuery = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,4 +1,4 @@
-import { query, update, sparqlEscapeUri } from 'mu';
+import { query, update, sparqlEscapeUri, sparqlEscapeString } from 'mu';
 
 export async function getImpersonatedSession(sessionUri) {
   const response = await query(`
@@ -42,7 +42,11 @@ export async function getImpersonatedSession(sessionUri) {
 }
 
 export async function setImpersonatedSession(sessionUri, accountUri) {
-  return await update(`
+
+  // The query has been split in pieces, because mu-auth is a bit restrictive
+  // If you need to write data to a graph you're permitted to write, but with data
+  // from a graph you're only required to read.
+  const insertOriginalAccountQuery = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
@@ -70,38 +74,73 @@ export async function setImpersonatedSession(sessionUri, accountUri) {
           muExt:originalSessionRole ?maybeOriginalSessionRole .
       }
     }
+  `;
+  await update(insertOriginalAccountQuery);
 
-    ;
+  const getDataToImpersonateQuery = `
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+    SELECT DISTINCT
+      ?impersonatedAccount
+      ?impersonatedSessionGroup
+      ?impersonatedSessionRole
+
+     WHERE {
+
+      VALUES ?impersonatedAccount {
+        ${sparqlEscapeUri(accountUri)}
+      }
+
+      ?impersonatedAccount muExt:sessionRole ?impersonatedSessionRole .
+
+       ?impersonatedUser foaf:account ?impersonatedAccount;
+         foaf:member ?impersonatedSessionGroup .
+      }
+  `;
+
+  const results = parseResult(await query(getDataToImpersonateQuery));
+
+  const removeOldSessionQuery = `
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
 
     DELETE {
       ?sessionUri muSession:account ?currentAccount ;
         muExt:sessionGroup ?currentSessionGroup ;
         muExt:sessionRole ?currentSessionRole .
     }
-    INSERT {
-      ?sessionUri muSession:account ?impersonatedAccount ;
-        muExt:sessionGroup ?impersonatedSessionGroup ;
-        muExt:sessionRole ?impersonatedSessionRole .
-    }
     WHERE {
       VALUES ?sessionUri {
         ${sparqlEscapeUri(sessionUri)}
       }
-
-      VALUES ?impersonatedAccount {
-        ${sparqlEscapeUri(accountUri)}
-      }
-
       ?sessionUri muSession:account ?currentAccount ;
         muExt:sessionGroup ?currentSessionGroup ;
         muExt:sessionRole ?currentSessionRole .
+    }`;
 
-      ?impersonatedAccount muExt:sessionRole ?impersonatedSessionRole .
+  await update(removeOldSessionQuery);
 
-      ?impersonatedUser foaf:account ?impersonatedAccount ;
-        foaf:member ?impersonatedSessionGroup .
-    }`
-  );
+  for(const result of results) {
+    const insertNewSessionQuery = `
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX muExt:  <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX muSession: <http://mu.semte.ch/vocabularies/session/>
+
+      INSERT DATA {
+        ${sparqlEscapeUri(sessionUri)} muSession:account ${sparqlEscapeUri(result['impersonatedAccount'])} ;
+          muExt:sessionGroup ${sparqlEscapeUri(result['impersonatedSessionGroup'])} ;
+          muExt:sessionRole ${sparqlEscapeString(result['impersonatedSessionRole'])} .
+      }
+    `;
+    await update(insertNewSessionQuery);
+  }
+
 }
 
 export async function deleteImpersonatedSession(sessionUri) {
@@ -117,7 +156,7 @@ export async function deleteImpersonatedSession(sessionUri) {
         muExt:originalAccount ?originalAccount ;
         muExt:originalSessionRole ?originalSessionRole ;
         muExt:originalSessionGroup ?originalSessionGroup .
-    } 
+    }
     INSERT {
       ${sparqlEscapeUri(sessionUri)} muSession:account ?originalAccount ;
         muExt:sessionGroup ?originalSessionGroup ;
@@ -133,3 +172,28 @@ export async function deleteImpersonatedSession(sessionUri) {
     }`
   );
 }
+
+/**
+ * convert results of select query to an array of objects.
+ * courtesy: Niels Vandekeybus & Felix
+ * @method parseResult
+ * @return {Array}
+ */
+function parseResult(result) {
+  if (!(result.results && result.results.bindings.length)) return [];
+
+  const bindingKeys = result.head.vars;
+  return result.results.bindings.map((row) => {
+    const obj = {};
+    bindingKeys.forEach((key) => {
+      if (row[key] && row[key].datatype == 'http://www.w3.org/2001/XMLSchema#integer' && row[key].value) {
+        obj[key] = parseInt(row[key].value);
+      }
+      else if (row[key] && row[key].datatype == 'http://www.w3.org/2001/XMLSchema#dateTime' && row[key].value) {
+        obj[key] = new Date(row[key].value);
+      }
+      else obj[key] = row[key] ? row[key].value : undefined;
+    });
+    return obj;
+  });
+};


### PR DESCRIPTION
Previously, the query to add an account for impersonation was executed as a single action. In some cases, this approach won't work:
- Mu-auth restricts the single query to all graphs it can write to.
- If some account information resides in graphs where the user has read-only access, Mu-auth will omit this graph, resulting in broken impersonation.

To deal with this,  the query has been split into separate parts.